### PR TITLE
Fix the unsmooth scroll after setPullLoadEnable(false) issue.

### DIFF
--- a/PullToRefresh/src/main/java/com/markmao/pulltorefresh/widget/XListView.java
+++ b/PullToRefresh/src/main/java/com/markmao/pulltorefresh/widget/XListView.java
@@ -163,7 +163,7 @@ public class XListView extends ListView implements OnScrollListener {
         if (!mEnablePullLoad) {
             mFooterView.setBottomMargin(0);
             mFooterView.hide();
-            mFooterView.setPadding(0, 0, 0, mFooterView.getHeight() * (-1));
+            mFooterView.setPadding(0, 0, 0, 0);
             mFooterView.setOnClickListener(null);
 
         } else {


### PR DESCRIPTION
fix this issue:https://github.com/MarkMjw/PullToRefresh/issues/5
problem: setPullLoadEnable(false) when no more item to get, the scroll will unsmooth.